### PR TITLE
OPS-2579 - add gettext-base

### DIFF
--- a/infra-tools/Dockerfile
+++ b/infra-tools/Dockerfile
@@ -39,7 +39,8 @@ RUN set -x \
         tmux \
         mtr-tiny \
         tcpdump \
-    && rm -rf /var/lib/apt/lists/* \
+        gettext-base \
     && curl -fsSL https://deb.nodesource.com/setup_lts.x | bash - \
-    && apt-get install -y nodejs
+    && apt-get install -y nodejs \
+    && apt-get clean -y
 


### PR DESCRIPTION
# Description

Add gettext-base to the list of packages to install. 
gettext-base included envsubst.

## Changes

Add gettext-base to the list of packages to install. 
gettext-base included envsubst.

## Datasecurity <sub><sup>details [on Confluence](https://docs.schul-cloud.org/x/2S3GBg)</sup></sub>



## Deployment


## New Repos, NPM pakages or vendor scripts


## Screenshots of UI changes


## Approval for review

- [x] All points were discussed with the ticket creator, support-team or product owner. The code upholds all quality guidelines from the PR-template.

> Notice: Please remove the WIP label if the PR is ready to review, otherwise nobody will review it.

### Link to Definiton of Done

More and detailed information on the _definition of done_ can be found [on Confluence](https://docs.schul-cloud.org/pages/viewpage.action?pageId=92831762)
