### PR TITLE
Ops 2850 check s3 buckets for duplicates

### DIFF
--- a/s3-backup/.gitignore
+++ b/s3-backup/.gitignore
@@ -1,5 +1,7 @@
 *_backupsizes/
 /log/
+/logs/
 *.log
 __pycache__/
 *.py[co]
+credentials

--- a/s3-backup/s3b_data/validation_result.py
+++ b/s3-backup/s3b_data/validation_result.py
@@ -196,7 +196,7 @@ class ValidationResult:
             self.bucket_infos[target_bucket_info.bucket_to_backup] = bucket_compare
         else:
             if bucket_compare.target_bucket_info != None:
-                raise S3bException('Cannot set target bucket. The target bucket is already set.')
+                raise S3bException("WARNING: Cannot set target bucket. The target bucket is already set. Bucket: '%s'" % (target_bucket_info))
             bucket_compare.target_bucket_info = target_bucket_info
     
     def compare(self):

--- a/s3-backup/s3b_logic/rclone.py
+++ b/s3-backup/s3b_logic/rclone.py
@@ -331,7 +331,11 @@ def run_backup_validate(s3_backup_config, instance_names_to_backup, current_day_
         for current_bucket_to_backup in target_bucket_list:
             defective_file_list = []
             target_bucket_info = read_bucket_info(current_instance.s3_target_drive.drivename, backup_path, current_bucket_to_backup, defective_file_list, whatif)
-            validation_result.add_target_bucket_info(target_bucket_info)
+            try:
+                validation_result.add_target_bucket_info(target_bucket_info)
+            except S3bException as ex:
+                logging.exception(ex)
+                logging.warning("WARNING: Cannot set target bucket. The target bucket is already set. Bucket: '%s'" % (target_bucket_info))
 
         # Compare the collected bucket information.
         logging.info("===== Validation Statistics %s =====" % current_instance.instancename)

--- a/s3-backup/s3b_logic/rclone.py
+++ b/s3-backup/s3b_logic/rclone.py
@@ -335,7 +335,6 @@ def run_backup_validate(s3_backup_config, instance_names_to_backup, current_day_
                 validation_result.add_target_bucket_info(target_bucket_info)
             except S3bException as ex:
                 logging.exception(ex)
-                logging.warning("WARNING: Cannot set target bucket. The target bucket is already set. Bucket: '%s'" % (target_bucket_info))
 
         # Compare the collected bucket information.
         logging.info("===== Validation Statistics %s =====" % current_instance.instancename)


### PR DESCRIPTION
# Description

S3 Backup script throws error on duplicates folders in S3 Backup with full backups.
we need a list of duplicates of all source buckets over all source buckets.
So Script should be changed to not abort with error but should put a warning in the log.

## Links to Tickets or other pull requests

https://ticketsystem.hpi-schul-cloud.org/browse/OPS-2850

## Changes

Add try catch to exeption on S3 bucket duplicates "Cannot set target bucket. The target bucket is already set."
Add bucket information to logging warning.

## Datasecurity <sub><sup>details [on Confluence](https://docs.schul-cloud.org/x/2S3GBg)</sup></sub>
N/D

## Deployment
branch runs on whatchamacallit, backup script with change will run tomorrow with full backup brb.

## New Repos, NPM pakages or vendor scripts
N/D

## Screenshots of UI changes
N/D

## Approval for review

- [x] All points were discussed with the ticket creator, support-team or product owner. The code upholds all quality guidelines from the PR-template.

> Notice: Please remove the WIP label if the PR is ready to review, otherwise nobody will review it.

### Link to Definiton of Done

More and detailed information on the _definition of done_ can be found [on Confluence](https://docs.schul-cloud.org/pages/viewpage.action?pageId=92831762)
