### PR TITLE
Ops 2938 reuseable workflow tf docs helm docs

### DIFF
--- a/.github/actions/helm-docs/Dockerfile
+++ b/.github/actions/helm-docs/Dockerfile
@@ -1,0 +1,8 @@
+
+FROM jnorwood/helm-docs:latest
+
+RUN apk add --no-cache bash
+RUN apk add --no-cache git
+
+COPY entrypoint.sh /entrypoint.sh
+ENTRYPOINT ["/bin/bash", "-c", "/entrypoint.sh"]

--- a/.github/actions/helm-docs/action.yml
+++ b/.github/actions/helm-docs/action.yml
@@ -1,0 +1,42 @@
+name: 'HelmDocs GithubAction'
+description: 'GitHub Action for automatically generating Documentation for Helm Charts'
+author: ''
+inputs:
+  src_path: 
+    description: 'Provide paths in which to recursively run the helm-docs command' 
+    default: . 
+    required: false
+  template_file: 
+    description: 'Provide template file for helm-docs' 
+    required: false
+  ignored_dirs: 
+    description: 'Dirs to ignore'
+    required: false
+  commit_message:
+    description: 'Custom git commit message'
+    required: false
+    default: 'Updating README.md via GithubActions (helm-docs)'
+  username:
+    description: 'The GitHub username to associate commits made by this GitHub action'
+    required: false
+    default: 'github-actions-bot'
+  email:
+    description: 'The email used for associating commits made by this GitHub action'
+    required: false
+    default: 'github-actions-bot@mail.com'
+  git_push: 
+    description: 'Configure, whether changes shall be commited and pushed or not'
+    required: false
+    default: "false"
+runs:
+  using: 'docker'
+  image: 'Dockerfile'
+  args:
+    - ${{ inputs.personal_token }}
+    - ${{ inputs.src_path }}
+    - ${{ inputs.commit_message }}
+    - ${{ inputs.username }}
+    - ${{ inputs.email }}
+    - ${{ inputs.template_file }}
+    - ${{ inputs.ignored_dirs }}
+    - ${{ inputs.git_push }}

--- a/.github/actions/helm-docs/entrypoint.sh
+++ b/.github/actions/helm-docs/entrypoint.sh
@@ -1,0 +1,94 @@
+#!/bin/bash
+
+# ENVS FROM ACTION YAML 
+PERSONAL_TOKEN="$INPUT_PERSONAL_TOKEN"
+SRC_PATH="$INPUT_SRC_PATH"
+COMMIT_MESSAGE="$INPUT_COMMIT_MESSAGE"
+USERNAME="$INPUT_USERNAME"
+EMAIL="$INPUT_EMAIL"
+TEMPLATE_FILE="$INPUT_TEMPLATE_FILE"
+IGNORED_DIRS="$INPUT_IGNORED_DIRS"
+GIT_PUSH="$INPUT_GIT_PUSH"
+# OTHER ENVS
+BASE_PATH=$(pwd)
+
+
+echo "-----Information:---------------------------"
+git --version
+helm-docs --version
+echo "Base path is: $BASE_PATH"
+if [ "${TEMPLATE_FILE}" != "" ]
+then
+    echo "Templates file location is: $TEMPLATE_FILE"
+else
+    echo "Template file is not provided"
+fi
+
+echo "----.helmdocsignore Status:----------------"
+
+FILE=$(pwd)/.helmdocsignore
+if test -f "$FILE"; then
+    echo "$FILE exists."
+else 
+    echo "Creating .helmdocsignore file"
+    touch .helmdocsignore
+fi
+
+# Updating .helmdocsignore file
+IFS=',' ;for DIR in ${IGNORED_DIRS}
+do 
+    if grep -Fxq "$DIR" .helmdocsignore
+    then 
+        echo "$DIR already in ignored list"
+    else 
+        echo "$DIR" >> .helmdocsignore
+        echo "$DIR added to the ignored list"
+    fi 
+done
+
+
+echo "----Updating README.md files in specified dirs:------"
+if [ "${TEMPLATE_FILE}" != "" ]
+then 
+    echo "Custom Template provided - using it"
+    IFS=',' ;for DIR in `echo "$SRC_PATH"`;
+    do 
+        echo "Checking README.md recursively in dir: $BASE_PATH/$DIR"
+        cd $BASE_PATH/$DIR
+        helm-docs --log-level warning --template-files $BASE_PATH/${TEMPLATE_FILE}
+    done
+else 
+    echo "Custom Template not provided - using default template"
+    IFS=',' ;for DIR in `echo "$SRC_PATH"`;
+    do 
+        echo "Checking README.md recursively in dir: $BASE_PATH/$DIR"
+        cd $BASE_PATH/$DIR
+        helm-docs --log-level warning
+    done
+fi 
+
+git config --global user.name "${USERNAME}"
+git config --global user.email "${EMAIL}"
+
+# Pushing Changes back to Repo 
+if [ -z "$(git status --porcelain)" ]
+then
+    # Working directory is clean
+    echo "No changes detected - nothing changed or pushed"
+else
+    echo "git_push is set to: ${GIT_PUSH}"
+    if [ "${GIT_PUSH}" == "true" ]
+    then 
+        # commit and push changes
+        echo "Changes detected - will commit and push"
+        git add -A
+        git commit --message "${COMMIT_MESSAGE}"
+        git push origin 
+    else
+        echo "Changes detected - will not commit or push"
+
+    fi
+fi
+
+echo "Complete 🟢"
+

--- a/.github/workflows/reuseable-workflow-tf-docs-helm-docs.yaml
+++ b/.github/workflows/reuseable-workflow-tf-docs-helm-docs.yaml
@@ -55,7 +55,7 @@ jobs:
         git-push-user-email: ${{ inputs.email }}
         git-push-user-name: ${{ inputs.name }}
     - name: Render Helm-Docs
-      uses: .github/actions/helm-docs
+      uses: ./.github/actions/helm-docs
       with:
         # provide name of dirs to run helm-docs on, separate by comma without space
         src_path: ${{ inputs.src_path_helm}}

--- a/.github/workflows/reuseable-workflow-tf-docs-helm-docs.yaml
+++ b/.github/workflows/reuseable-workflow-tf-docs-helm-docs.yaml
@@ -1,0 +1,67 @@
+# https://github.com/terraform-docs/gh-actions
+# https://github.com/norwoodj/helm-docs
+ 
+name: Generate Terraform-Docs && Helm-Docs
+on:
+  workflow_call:
+    inputs:
+      name:
+        description: "Name on which to push changes to github"
+        required: true
+        type: string
+      email:
+        description: "Email on which to push changes to github"
+        required: true
+        type: string
+      src_path_tf:
+        description: "Provide dir on which to run tf-docs"
+        required: false
+        type: string
+      terraform_docs_config_file:
+        description: "Name custom tf-docs template file if existing"
+        required: false
+        type: string
+      src_path_helm:
+        description: "Provide dirs on which to run helm-docs, can be multiple, separate by comma without space"
+        required: false
+        type: string
+      helm_docs_template_file:
+        description: "Name custom helm-docs template file if existing"
+        required: false
+        type: string
+      helm_ignored_dirs:
+        description: "Provide dirs name to ignore, can be multiple, separate by comma without space"
+        required: false
+        type: string
+ 
+jobs:
+  create_tf-docs_and_helm-docs:
+    runs-on: ubuntu-latest
+    steps:
+    - name: Checking out code to Runner
+      uses: actions/checkout@v2
+      with:
+        ref: ${{ github.event.pull_request.head.ref }}    
+    - name: Render Terraform-Docs
+      uses: terraform-docs/gh-actions@v0.11.0
+      with:
+        find-dir: ${{ inputs.src_path_tf}}
+        config-file:  ${{ inputs.terraform_docs_config_file }}
+        output-file: README.md
+        # other methods "replace" or "reprint", "inject"
+        output-method: replace
+        git-push: true
+        git-commit-message: "Updating README.md via GithubActions (tf-docs)"
+        git-push-user-email: ${{ inputs.email }}
+        git-push-user-name: ${{ inputs.name }}
+    - name: Render Helm-Docs
+      uses: .github/actions/helm-docs
+      with:
+        # provide name of dirs to run helm-docs on, separate by comma without space
+        src_path: ${{ inputs.src_path_helm}}
+        template_file: ${{ inputs.helm_docs_template_file }}
+        # provide name of dirs to ignore, separate by comma without space
+        ignored_dirs: ${{ inputs.helm_ignored_dirs}}
+        git_push: true 
+        username: ${{ inputs.name }}
+        email: ${{ inputs.email }}


### PR DESCRIPTION
# Description

- add github action, that renders README.md with helm-docs 
- add reuseable workflow to create tf-docs and helm-docs

## Links to Tickets or other pull requests
https://ticketsystem.hpi-schul-cloud.org/browse/OPS-2938
https://github.com/terraform-docs/gh-actions
https://github.com/norwoodj/helm-docs


## Changes

<!--
  What will the PR change?
  Why are the changes requiered?
  Short notice if a ticket exists, more detailed if not
-->

## Datasecurity <sub><sup>details [on Confluence](https://docs.schul-cloud.org/x/2S3GBg)</sup></sub>

n/a

## Deployment
n/a

## New Repos, NPM pakages or vendor scripts

- makes use of https://github.com/terraform-docs/gh-actions

## Screenshots of UI changes

n/a

## Approval for review

- [ ] All points were discussed with the ticket creator, support-team or product owner. The code upholds all quality guidelines from the PR-template.

> Notice: Please remove the WIP label if the PR is ready to review, otherwise nobody will review it.

### Link to Definiton of Done

More and detailed information on the _definition of done_ can be found [on Confluence](https://docs.schul-cloud.org/pages/viewpage.action?pageId=92831762)
