### PR TITLE
OPS-3305: dbcmetrics storage monitoring doesn't recognize folders if they aren't an object

### DIFF
--- a/dbcmetrics/dbcm_logic/dbcstorage.py
+++ b/dbcmetrics/dbcm_logic/dbcstorage.py
@@ -44,33 +44,33 @@ class StorageMetricsThreading(object):
             'name',
             'storage_provider_url',
             'access_key',
-            ])
+        ])
 
         self.size_bucket_gauge = Gauge('storage_size_bucket','The total size in bytes of all files in a bucket',[
             'name',
             'storage_provider_url',
             'access_key',
-            ])
+        ])
 
         self.file_count_bucket_gauge = Gauge('storage_file_count_bucket','The total number of files in a bucket',[
             'name',
             'storage_provider_url',
             'access_key',
-            ])
+        ])
 
         self.size_folder_gauge = Gauge('storage_size_folder','The total size in bytes of all files in a folder',[
             'name',
             'bucket',
             'storage_provider_url',
             'access_key',
-            ])
+        ])
 
         self.file_count_folder_gauge = Gauge('storage_file_count_folder','The total number of files in a folder',[
             'name',
             'bucket',            
             'storage_provider_url',
             'access_key',
-            ])
+        ])
 
         self.thread = threading.Thread(target=self.run)
         self.thread.daemon = True
@@ -101,7 +101,7 @@ class StorageMetricsThreading(object):
                     Bucket=self.storage_bucket_name,
                     ContinuationToken=marker,
                     FetchOwner=False,
-                    )
+                )
                 total_keys += response['KeyCount']
                 marker = response.get('NextContinuationToken')
                 incomplete = response['IsTruncated']
@@ -112,7 +112,7 @@ class StorageMetricsThreading(object):
                     name=self.storage_bucket_name,
                     storage_provider_url=self.storage_provider_url,
                     access_key=self.storage_access_key,
-                    ).set(0.0)
+                ).set(0.0)
                 return
 
         logging.debug("The total number of keys in the bucket {} is {}".format(self.storage_bucket_name, total_keys))
@@ -121,7 +121,7 @@ class StorageMetricsThreading(object):
             name=self.storage_bucket_name,
             storage_provider_url=self.storage_provider_url,
             access_key=self.storage_access_key,
-            ).set(1.0)
+        ).set(1.0)
 
         # Remove folder objects from object_list because files can be in folders by adding a slash to the path without the folders themselfes existing as objects in the bucket
         file_list = [obj for obj in object_list if obj['Key'].endswith('/') == False]


### PR DESCRIPTION
# Description

<!--
  This is a template to add as many information as possible to the pull request, to help reviewer and as a checklist for you. Points to remember are set in the comments, please read and keep them in mind:

    - Code should be self-explanatory and share your knowledge with others
    - Document code that is not self-explanatory
    - Think about bugs and keep security in mind
    - Write tests (Unit and Integration), also for error cases
    - Main logic should hidden behind the api, never trust the client
    - Visible changes should be discussed with the UX-Team from the begining of development; they also have to accept them at the end
    - Keep the changelog up-to-date
    - Leave the code cleaner than you found it. Remove unnecessary lines. Listen to the linter.
-->

## Links to Tickets or other pull requests

[OPS-3305: dbcmetrics storage monitoring doesn't recognize folders if they aren't an object](https://ticketsystem.dbildungscloud.de/browse/OPS-3305)


## Changes

Fixed a bug where folders weren't recognized if they weren't saved as a dedicated s3 object by implementing logic to parse folders from the file path strings

## Deployment

Deployment on Infra and Dev is done. Metrics on both environments look exactly as expected. See [Infra-Dev Grafana Explore Mode](https://grafana.infra-dev-servicecenter-1.dbildungscloud.dev/explore?left=%5B%22now-1h%22,%22now%22,%22Victoriametrics%22,%7B%22datasource%22:%7B%22type%22:%22prometheus%22,%22uid%22:%22P4455A22B976CD9FA%22%7D,%22exemplar%22:false,%22expr%22:%22version_info%22,%22format%22:%22table%22,%22instant%22:true,%22interval%22:%22%22,%22refId%22:%22A%22,%22hide%22:false%7D,%7B%22refId%22:%22B%22,%22instant%22:true,%22range%22:true,%22exemplar%22:true,%22expr%22:%22storage_bucket_availability%22,%22hide%22:false%7D,%7B%22refId%22:%22C%22,%22instant%22:true,%22range%22:true,%22exemplar%22:true,%22expr%22:%22storage_file_count_bucket%22%7D,%7B%22refId%22:%22D%22,%22instant%22:true,%22range%22:true,%22exemplar%22:true,%22expr%22:%22storage_size_bucket%22%7D,%7B%22refId%22:%22E%22,%22instant%22:true,%22range%22:true,%22exemplar%22:true,%22expr%22:%22storage_file_count_folder%22%7D,%7B%22refId%22:%22F%22,%22instant%22:true,%22range%22:true,%22exemplar%22:true,%22expr%22:%22storage_size_folder%22%7D%5D&orgId=1) and [Dev Grafana Explore Mode](https://grafana.dbildungscloud.dev/explore?left=%5B%22now-15m%22,%22now%22,%22Victoriametrics%22,%7B%22datasource%22:%7B%22type%22:%22prometheus%22,%22uid%22:%22P4455A22B976CD9FA%22%7D,%22exemplar%22:false,%22expr%22:%22version_info%22,%22format%22:%22table%22,%22instant%22:true,%22interval%22:%22%22,%22refId%22:%22A%22,%22hide%22:false%7D,%7B%22refId%22:%22B%22,%22instant%22:true,%22range%22:true,%22exemplar%22:true,%22expr%22:%22storage_bucket_availability%22,%22hide%22:false%7D,%7B%22refId%22:%22C%22,%22instant%22:true,%22range%22:true,%22exemplar%22:true,%22expr%22:%22storage_file_count_bucket%22%7D,%7B%22refId%22:%22D%22,%22instant%22:true,%22range%22:true,%22exemplar%22:true,%22expr%22:%22storage_size_bucket%22%7D,%7B%22refId%22:%22E%22,%22instant%22:true,%22range%22:true,%22exemplar%22:true,%22expr%22:%22storage_file_count_folder%22%7D,%7B%22refId%22:%22F%22,%22instant%22:true,%22range%22:true,%22exemplar%22:true,%22expr%22:%22storage_size_folder%22%7D%5D&orgId=1) for more information.

## Approval for review

- [ ] All points were discussed with the ticket creator, support-team or product owner. The code upholds all quality guidelines from the PR-template.

> Notice: Please remove the WIP label if the PR is ready to review, otherwise nobody will review it.

### Link to Definiton of Done

More and detailed information on the _definition of done_ can be found [on Confluence](https://docs.schul-cloud.org/pages/viewpage.action?pageId=92831762)
