### PR TITLE
BC-3560 Deal with Docker's discontinuation of Free Team organizations

### DIFF
--- a/image-repository-replicator/Dockerfile
+++ b/image-repository-replicator/Dockerfile
@@ -1,0 +1,6 @@
+FROM gcr.io/go-containerregistry/crane:debug
+
+WORKDIR /usr/src/app
+COPY image_repository_replication.sh image_repository_replication.sh
+
+ENTRYPOINT [ "/busybox/sh", "image_repository_replication.sh" ]

--- a/image-repository-replicator/README.md
+++ b/image-repository-replicator/README.md
@@ -9,6 +9,8 @@ The following environment variables are read by the image-repository-replication
 | Name        | Description | Example Value |
 | ----------- | ----------- | ------------- |
 | SOURCE_REPOSITORY_URL | The source container image repository for the replication | `docker.io/schulcloud/schulcloud-server` |
+| SOURCE_REGISTRY_USER | The user to authenticate crane at the source registry | `mustermann` |
+| SOURCE_REGISTRY_PASSWORD | The user password to authenticate at the source registry | `4GXJXE9fenD3jZnzjQFa` (random generated) |
 | DEST_REPOSITORY_URL | The destination container image repository for the replication | `docker.io/schulcloud/schulcloud-server` |
-| REGISTRY_USER | The container image registry user which is used to authenticate crane at the registry | `mustermann` |
-| REGISTRY_PASSWORD | The password of the container image registry user | `mkMfCRMp8GpwZwXzkJbp` (random generated) |
+| DEST_REGISTRY_USER | The user to authenticate crane at the destination registry | `musterfrau` |
+| DEST_REGISTRY_PASSWORD | The user password to authenticate at the destination registry | `m29VK2uezrzaRCYUiVPD` (random generated) |

--- a/image-repository-replicator/README.md
+++ b/image-repository-replicator/README.md
@@ -1,0 +1,14 @@
+# Image Repository Replicator
+The purpose of this tool is to replicate a container image repository from one registry to another.
+
+## Configuration
+
+### Environment Variables
+
+The following environment variables are read by the image-repository-replication application:
+| Name        | Description | Example Value |
+| ----------- | ----------- | ------------- |
+| SOURCE_REPOSITORY_URL | The source container image repository for the replication | `docker.io/schulcloud/schulcloud-server` |
+| DEST_REPOSITORY_URL | The destination container image repository for the replication | `docker.io/schulcloud/schulcloud-server` |
+| REGISTRY_USER | The container image registry user which is used to authenticate crane at the registry | `mustermann` |
+| REGISTRY_PASSWORD | The password of the container image registry user | `mkMfCRMp8GpwZwXzkJbp` (random generated) |

--- a/image-repository-replicator/README.md
+++ b/image-repository-replicator/README.md
@@ -9,8 +9,31 @@ The following environment variables are read by the image-repository-replication
 | Name        | Description | Example Value |
 | ----------- | ----------- | ------------- |
 | SOURCE_REPOSITORY_URL | The source container image repository for the replication | `docker.io/schulcloud/schulcloud-server` |
-| SOURCE_REGISTRY_USER | The user to authenticate crane at the source registry | `mustermann` |
+| SOURCE_REGISTRY_USER | The user to authenticate crane at the source registry | `myuser` |
 | SOURCE_REGISTRY_PASSWORD | The user password to authenticate at the source registry | `4GXJXE9fenD3jZnzjQFa` (random generated) |
 | DEST_REPOSITORY_URL | The destination container image repository for the replication | `docker.io/schulcloud/schulcloud-server` |
-| DEST_REGISTRY_USER | The user to authenticate crane at the destination registry | `musterfrau` |
+| DEST_REGISTRY_USER | The user to authenticate crane at the destination registry | `myotheruser` |
 | DEST_REGISTRY_PASSWORD | The user password to authenticate at the destination registry | `m29VK2uezrzaRCYUiVPD` (random generated) |
+
+# How to run
+
+## As a standalone container
+
+Build an container image by running bash the command
+```
+docker build --rm -f ./Dockerfile -t image-repository-replicator .
+```
+
+Then run a container from the image by executing the command
+```
+docker run \
+    --name image-repository-replicator \
+    --rm \
+    -e SOURCE_REPOSITORY_URL="<your source repository url>" \
+    -e SOURCE_REGISTRY_USER="<your source registry user>" \
+    -e SOURCE_REGISTRY_PASSWORD="<your source registry user password>" \
+    -e DEST_REPOSITORY_URL="<your destination repository url>" \
+    -e DEST_REGISTRY_USER="<your destination registry user>" \
+    -e DEST_REGISTRY_PASSWORD="<your destination registry user password>" \
+    image-repository-replicator:latest
+```

--- a/image-repository-replicator/image_repository_replication.sh
+++ b/image-repository-replicator/image_repository_replication.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/bin/sh
 
 log_in_registry () {
   echo "log in with user $2 in registry $1"
@@ -10,9 +10,9 @@ get_repository_image_tags () {
 }
 
 copy_repository () {
-  while read -r image_tag ; do
+  echo "$image_tags" | while read -r image_tag ; do
     copy_image $1 $2 ${image_tag}
-  done <<< "$image_tags"
+  done
 }
 
 copy_image () {
@@ -28,7 +28,7 @@ echo $(log_in_registry ${SOURCE_REPOSITORY_URL%%/*} ${SOURCE_REGISTRY_USER} ${SO
 echo $(log_in_registry ${DEST_REPOSITORY_URL%%/*} ${DEST_REGISTRY_USER} ${DEST_REGISTRY_PASSWORD})
 
 image_tags="$(get_repository_image_tags ${SOURCE_REPOSITORY_URL})"
-number_of_image_tags="$(wc -l <<< "$image_tags")"
+number_of_image_tags="$(echo "$image_tags" | wc -l )"
 echo "Copy ${number_of_image_tags} tagged images from repository ${SOURCE_REPOSITORY_URL} to ${DEST_REPOSITORY_URL}"
 echo $(copy_repository ${SOURCE_REPOSITORY_URL} ${DEST_REPOSITORY_URL})
 

--- a/image-repository-replicator/image_repository_replication.sh
+++ b/image-repository-replicator/image_repository_replication.sh
@@ -1,0 +1,38 @@
+#!/bin/bash
+
+log_in_registry () {
+  echo "log in with user $2 in registry $1"
+  echo "$(crane auth login $1 -u $2 -p $3)"
+}
+
+get_repository_image_tags () {
+  echo "$(crane ls $1)"
+}
+
+copy_repository () {
+  while read -r image_tag ; do
+    copy_image $1 $2 ${image_tag}
+  done <<< "$image_tags"
+}
+
+copy_image () {
+  crane cp $1:$3 $2:$3
+}
+
+start=`date +%s`
+
+# Log in to the source registry to avoid pull limits
+echo $(log_in_registry ${SOURCE_REPOSITORY_URL%%/*} ${SOURCE_REGISTRY_USER} ${SOURCE_REGISTRY_PASSWORD})
+
+# Log in to the destination registry to get permission to push
+echo $(log_in_registry ${DEST_REPOSITORY_URL%%/*} ${DEST_REGISTRY_USER} ${DEST_REGISTRY_PASSWORD})
+
+image_tags="$(get_repository_image_tags ${SOURCE_REPOSITORY_URL})"
+number_of_image_tags="$(wc -l <<< "$image_tags")"
+echo "Copy ${number_of_image_tags} tagged images from repository ${SOURCE_REPOSITORY_URL} to ${DEST_REPOSITORY_URL}"
+echo $(copy_repository ${SOURCE_REPOSITORY_URL} ${DEST_REPOSITORY_URL})
+
+end=`date +%s`
+runtime=$((end-start))
+hours=$((runtime / 3600)); minutes=$(( (runtime % 3600) / 60 )); seconds=$(( (runtime % 3600) % 60 ));
+echo "Copying of ${number_of_image_tags} tagged images from repository ${SOURCE_REPOSITORY_URL} to ${DEST_REPOSITORY_URL} took ${hours}h ${minutes}m ${seconds}s"


### PR DESCRIPTION
# Description

Created a container image which is able to fetch all tags from a configured source image repository and copies them to the destination image repository.

## Links to Tickets or other pull requests

BC-3560

## Changes

Adding a Dockerfile which uses [crane](https://github.com/google/go-containerregistry/tree/main/cmd/crane) as a base image and adds a bash script to copy all tags from a source image repository to a destination image repository

## Deployment

Not deployed and not pushed to a container registry yet.

## Approval for review

- [ ] All points were discussed with the ticket creator, support-team or product owner. The code upholds all quality guidelines from the PR-template.

> Notice: Please remove the WIP label if the PR is ready to review, otherwise nobody will review it.
