### PR TITLE
OPS-5284 Update curl CVE-2023-38545 CVE-2023-38546

### DIFF
--- a/awx-ee/Dockerfile
+++ b/awx-ee/Dockerfile
@@ -82,6 +82,7 @@ ARG OP_VERSION=2.18.0
 RUN pip3 install --upgrade pip setuptools
 RUN dnf install -y unzip
 RUN dnf install -y openssl
+RUN dnf upgrade libcurl-minimal -y
 RUN cd /tmp && curl -LO https://releases.hashicorp.com/terraform/$TERRAFORM_VERSION/terraform_${TERRAFORM_VERSION}_linux_amd64.zip && unzip terraform_${TERRAFORM_VERSION}_linux_amd64.zip && install -o root -g root -m 0755 terraform /usr/local/bin/terraform
 RUN curl -LO https://dl.k8s.io/release/$KUBECTL_VERSION/bin/linux/amd64/kubectl
 RUN install -o root -g root -m 0755 kubectl /usr/local/bin/kubectl

--- a/awx-ee/execution-environment.yml
+++ b/awx-ee/execution-environment.yml
@@ -26,6 +26,7 @@ additional_build_steps:
     RUN pip3 install --upgrade pip setuptools
     RUN dnf install -y unzip
     RUN dnf install -y openssl
+    RUN dnf upgrade libcurl-minimal -y
     RUN cd /tmp && curl -LO https://releases.hashicorp.com/terraform/$TERRAFORM_VERSION/terraform_${TERRAFORM_VERSION}_linux_amd64.zip && unzip terraform_${TERRAFORM_VERSION}_linux_amd64.zip && install -o root -g root -m 0755 terraform /usr/local/bin/terraform
     RUN curl -LO https://dl.k8s.io/release/$KUBECTL_VERSION/bin/linux/amd64/kubectl
     RUN install -o root -g root -m 0755 kubectl /usr/local/bin/kubectl


### PR DESCRIPTION
# Description
Upgrade libcurl version to version [ libcurl-minimal-7.76.1-28](https://kojihub.stream.centos.org/koji/buildinfo?buildID=39513) to address CVE-2023-38545 & CVE-2023-38546.

Not tested but this is unlikely to break the awx execution environment and even so, changing it back is possible from awx ui.


## Links to Tickets or other pull requests

<!--
Base links to copy
- https://github.com/hpi-schul-cloud/schulcloud-server/pull/????
- https://ticketsystem.dbildungscloud.de/browse/BC-????
-->

## Changes

<!--
  What will the PR change?
  Why are the changes requiered?
  Short notice if a ticket exists, more detailed if not
-->

## Datasecurity
Upgrade libcurl version to address CVE-2023-38545
<!--
  Notice about:
  - model changes
  - logging of user data
  - right changes
  - and other user data stuff
  If you are not sure if it is relevant, take a look at confluence or ask the data-security team.
-->

## Deployment

<!--
  Keep in mind to changes to seed data, if changes are done by migration scripts.
  Changes to the infrastructure have to discussed with the devops

  This point should includes following informations:
  - What is required for deployment?
  - Environement variables like FEATURE_XY=true
  - Migration scripts to run, other requirements
-->

## New Repos, NPM pakages or vendor scripts

<!--
  Keep in mind the stability, performance, activity and author.

  Describe why it is needed.
-->

## Screenshots of UI changes

<!--
  only needed for visual changes

  If visual changes exist, work together with UI/UX from beginning/ping UX with final PR
-->

## Approval for review

- [ ] All points were discussed with the ticket creator, support-team or product owner. The code upholds all quality guidelines from the PR-template.

> Notice: Please remove the WIP label if the PR is ready to review, otherwise nobody will review it.
