### PR TITLE
faet(awx-ee): OPS-10633 install age in awx runner

### DIFF
--- a/awx-ee/Dockerfile
+++ b/awx-ee/Dockerfile
@@ -8,7 +8,7 @@ ARG ANSIBLE_INSTALL_REFS="ansible-core==2.18.6 ansible-runner==2.4.1"
 ARG PKGMGR="/usr/bin/dnf"
 
 # Base build stage
-FROM $EE_BASE_IMAGE as base
+FROM $EE_BASE_IMAGE AS base
 USER root
 ENV PIP_BREAK_SYSTEM_PACKAGES=1
 ARG EE_BASE_IMAGE
@@ -27,7 +27,7 @@ RUN /output/scripts/pip_install $PYCMD
 RUN $PYCMD -m pip install --no-cache-dir $ANSIBLE_INSTALL_REFS
 
 # Galaxy build stage
-FROM base as galaxy
+FROM base AS galaxy
 ARG EE_BASE_IMAGE
 ARG PYCMD
 ARG PYPKG
@@ -46,7 +46,7 @@ RUN ansible-galaxy role install $ANSIBLE_GALAXY_CLI_ROLE_OPTS -r requirements.ym
 RUN ANSIBLE_GALAXY_DISABLE_GPG_VERIFY=1 ansible-galaxy collection install $ANSIBLE_GALAXY_CLI_COLLECTION_OPTS -r requirements.yml --collections-path "/usr/share/ansible/collections"
 
 # Builder build stage
-FROM base as builder
+FROM base AS builder
 ENV PIP_BREAK_SYSTEM_PACKAGES=1
 WORKDIR /build
 ARG EE_BASE_IMAGE
@@ -68,7 +68,7 @@ RUN $PYCMD /output/scripts/introspect.py introspect --user-pip=requirements.txt 
 RUN /output/scripts/assemble
 
 # Final build stage
-FROM base as final
+FROM base AS final
 ENV PIP_BREAK_SYSTEM_PACKAGES=1
 ARG EE_BASE_IMAGE
 ARG PYCMD
@@ -83,9 +83,10 @@ ARG HELM_VERSION=3.18.2
 ARG TERRAFORM_VERSION=1.5.4
 ARG KUBECTL_VERSION=1.33.7
 ARG OP_VERSION=2.31.0
+ARG AGE_VERSION=1.3.1
 RUN pip3 install --upgrade pip setuptools
-RUN dnf install -y unzip
-RUN dnf install -y openssl
+RUN dnf install -y unzip openssl
+RUN cd /tmp && curl -L -o age.tar.gz https://github.com/FiloSottile/age/releases/download/v${AGE_VERSION}/age-v${AGE_VERSION}-linux-amd64.tar.gz && tar -xzf age.tar.gz && install -o root -g root -m 0755 age/age /usr/local/bin/age && rm -rf age age.tar.gz
 RUN dnf upgrade libcurl-minimal -y
 RUN dnf upgrade --refresh
 RUN cd /tmp && curl -LO https://releases.hashicorp.com/terraform/$TERRAFORM_VERSION/terraform_${TERRAFORM_VERSION}_linux_amd64.zip && unzip terraform_${TERRAFORM_VERSION}_linux_amd64.zip && install -o root -g root -m 0755 terraform /usr/local/bin/terraform

--- a/awx-ee/_build/scripts/check_galaxy
+++ b/awx-ee/_build/scripts/check_galaxy
@@ -26,11 +26,13 @@ if [ $? -ne 0 ]
 then
     cat<<EOF
 **********************************************************************
-ERROR - Missing Ansible installation
+ERROR - 'ansible-galaxy' command not functioning as expected
 
-  The 'ansible-galaxy' command is not found in the base image. This
-  image is used to create the intermediary image that performs the
-  Galaxy collection and role installation process.
+  There was an error running the 'ansible-galaxy' command. Some
+  possible causes are 'ansible-core' missing from the base image, an
+  incorrect 'ansible.cfg', or 'ansible-galaxy' not being available to
+  the selected Python interpreter. Please use the -vvv option to
+  examine the build output for any errors.
 
   Ansible must be installed in the base image. If you are using a
   recent enough version of the execution environment file, you may

--- a/awx-ee/execution-environment.yml
+++ b/awx-ee/execution-environment.yml
@@ -20,10 +20,12 @@ additional_build_steps:
   prepend_final: |
     ARG HELM_VERSION=3.18.2
     ARG TERRAFORM_VERSION=1.5.4
-    ARG KUBECTL_VERSION=1.30.7
+    ARG KUBECTL_VERSION=1.33.7
     ARG OP_VERSION=2.31.0
+    ARG AGE_VERSION=1.3.1
     RUN pip3 install --upgrade pip setuptools
-    RUN dnf install -y unzip openssl age
+    RUN dnf install -y unzip openssl
+    RUN cd /tmp && curl -L -o age.tar.gz https://github.com/FiloSottile/age/releases/download/v${AGE_VERSION}/age-v${AGE_VERSION}-linux-amd64.tar.gz && tar -xzf age.tar.gz && install -o root -g root -m 0755 age/age /usr/local/bin/age && rm -rf age age.tar.gz
     RUN dnf upgrade libcurl-minimal -y
     RUN dnf upgrade --refresh
     RUN cd /tmp && curl -LO https://releases.hashicorp.com/terraform/$TERRAFORM_VERSION/terraform_${TERRAFORM_VERSION}_linux_amd64.zip && unzip terraform_${TERRAFORM_VERSION}_linux_amd64.zip && install -o root -g root -m 0755 terraform /usr/local/bin/terraform

--- a/awx-ee/execution-environment.yml
+++ b/awx-ee/execution-environment.yml
@@ -23,8 +23,7 @@ additional_build_steps:
     ARG KUBECTL_VERSION=1.30.7
     ARG OP_VERSION=2.31.0
     RUN pip3 install --upgrade pip setuptools
-    RUN dnf install -y unzip
-    RUN dnf install -y openssl
+    RUN dnf install -y unzip openssl age
     RUN dnf upgrade libcurl-minimal -y
     RUN dnf upgrade --refresh
     RUN cd /tmp && curl -LO https://releases.hashicorp.com/terraform/$TERRAFORM_VERSION/terraform_${TERRAFORM_VERSION}_linux_amd64.zip && unzip terraform_${TERRAFORM_VERSION}_linux_amd64.zip && install -o root -g root -m 0755 terraform /usr/local/bin/terraform


### PR DESCRIPTION
# Description

To enable encryption via all ssh keys for the kubeconfigs we need the age package installed in the ansible runner. 
(kubectl version was updated in the execution-environment.yml as it was previously only done in the Dockerfile which is auto generated by the  ansible-builder)

<!--
  This is a template to add as much information as possible to the pull request, to help reviewer and as a checklist for you. Points to remember are set in the comments, please read and keep them in mind:
    - Code should be self-explanatory and share your knowledge with others
    - Document code that is not self-explanatory
    - Think about bugs and keep security in mind
    - Write tests (Unit and Integration), also for error cases
    - Main logic should be hidden behind the api, never trust the client
    - Visible changes should be discussed with the UX-Team from the beginning of development; they also have to accept them at the end
    - Keep the changelog up-to-date
    - Leave the code cleaner than you found it. Remove unnecessary lines. Listen to the linter.
-->

## Links to Tickets or other pull requests
https://ticketsystem.dbildungscloud.de/browse/OPS-10633
<!-- related-prs-and-tickets-start -->
<!-- related-prs-and-tickets-end -->

## Screenshots of UI changes

<!--
  only needed for visual changes
  If visual changes exist, work together with UI/UX from beginning/ping UX with final PR
-->

## Approval for review

- [ ] DEV: If the API or client code was changed, all necessary code generation or synchronization steps were completed and tested.
- [ ] QA: In addition to review, the code has been manually tested (if manual testing is possible)
- [ ] All points were discussed with the ticket creator, support-team or product owner. The code upholds all quality guidelines from the PR-template.

